### PR TITLE
fix: domain typo

### DIFF
--- a/pve1/infrastructure/traefik/docker-compose.yaml
+++ b/pve1/infrastructure/traefik/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - 'traefik.http.routers.traefik-secure.tls=true'
       - 'traefik.http.routers.traefik-secure.tls.certresolver=cloudflare'
       - 'traefik.http.routers.traefik-secure.tls.domains[0].main=local.michaelcook.dev'
-      - 'traefik.http.routers.traefik-secure.tls.domains[0].sans=*.local.michaeldook.dev'
+      - 'traefik.http.routers.traefik-secure.tls.domains[0].sans=*.local.michaelcook.dev'
       - 'traefik.http.routers.traefik-secure.tls.domains[1].main=michaelcook.dev'
       - 'traefik.http.routers.traefik-secure.tls.domains[1].sans=*.michaelcook.dev'
       - 'traefik.http.routers.traefik-secure.service=api@internal'


### PR DESCRIPTION
https://community.traefik.io/t/traefik-cannot-resolve-wildcard-cert-for-subdomain-due-to-failure-to-find-zone-can-resolve-certificate-with-lego-directly/21432/13